### PR TITLE
feat: reflect properties to attributes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,9 +7,11 @@ auro-loader is an easy to use animated loader component
 | Attribute | Type      | Description                                      |
 |-----------|-----------|--------------------------------------------------|
 | `lg`      | `Boolean` | sets size to lg                                  |
+| `md`      | `Boolean` | sets size to md                                  |
 | `ondark`  | `Boolean` | sets color of loader to auro-color-ui-default-on-dark |
 | `onlight` | `Boolean` | sets color of loader to auro-color-ui-default-on-light |
 | `pulse`   | `Boolean` | sets loader type                                 |
+| `sm`      | `Boolean` | sets size to sm                                  |
 | `white`   | `Boolean` | sets color of loader to white                    |
 | `xl`      | `Boolean` | sets size to xl                                  |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-loader",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-loader.js
+++ b/src/auro-loader.js
@@ -46,21 +46,29 @@ class AuroLoader extends LitElement {
     /**
      * @private internal var
      */
-    this.md = 3;
+    this.mdCount = 3;
 
     /**
      * @private internal var
      */
-    this.sm = 2;
+    this.smCount = 2;
   }
 
   // function to define props used within the scope of this component
   static get properties() {
     return {
-      // ...super.properties,
-      orbit: { type: Boolean},
-      ringworm: { type: Boolean},
-      laser: { type: Boolean}
+      orbit: {
+        type: Boolean,
+        reflect: true
+      },
+      ringworm: {
+        type: Boolean,
+        reflect: true
+      },
+      laser: {
+        type: Boolean,
+        reflect: true
+      }
     };
   }
 
@@ -75,10 +83,10 @@ class AuroLoader extends LitElement {
    * @returns {array} numbered array for template map
    */
   defineTemplate() {
-    let nodes = Array.from(Array(this.md).keys());
+    let nodes = Array.from(Array(this.mdCount).keys());
 
     if (this.orbit || this.laser) {
-      nodes = Array.from(Array(this.sm).keys());
+      nodes = Array.from(Array(this.smCount).keys());
     } else if (this.ringworm) {
       nodes = Array.from(Array(0).keys());
     }


### PR DESCRIPTION
# Alaska Airlines Pull Request

This improves compatibility with Svelte and Preact by reflecting properties to attributes. 

## Summary:

Svelte and Preact favor setting properties instead of attributes for custom elements. Since this component relies on the presence of those attributes on the host element to set styles, the element did not display properly in those frameworks.

In the future, we should reflect properties that we want to use for styling to prevent these issues.

I also renamed the internal `sm` and `md` properties. This was causing a similar issue -- the frameworks thought these were equivalent to the `sm` and `md` attributes we were setting.

## Type of change:

Please delete options that are not relevant.

- [x] New capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
