### PR TITLE
fix: rollback auro-library to fix generateDoc scripting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@aurodesignsystem/auro-loader",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-loader",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-library": "^2.10.1",
+        "@aurodesignsystem/auro-library": "~2.8",
         "chalk": "^5.3.0",
         "lit": "^3.2.1"
       },
@@ -69,12 +69,11 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-2.10.1.tgz",
-      "integrity": "sha512-KFB3JbPigqYJSmEr8b0Iy924znnF07fcKx16LWf3hV9rf6fjxehWMejZce1gPHEbl5Oog1xBIdhPyjpfr9g6bQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-2.8.0.tgz",
+      "integrity": "sha512-oTRTd05JE3BVVQC3P11jTDGmTKXCi/Yi6XtKTp8dZVC+euJLDsySjVctAplqmOD3JqqwbJgtbNdlK7DpGRuCXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "handlebars": "^4.7.8",
         "markdown-magic": "^2.6.1",
         "npm-run-all": "^4.1.5"
       },
@@ -7533,6 +7532,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -7554,6 +7554,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9928,6 +9929,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10145,6 +10147,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nerf-dart": {
@@ -17358,6 +17361,7 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -17974,6 +17978,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wordwrapjs": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": "^18.x || ^20.x "
   },
   "dependencies": {
-    "@aurodesignsystem/auro-library": "^2.8",
+    "@aurodesignsystem/auro-library": "~2.8",
     "chalk": "^5.3.0",
     "lit": "^3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": "^18.x || ^20.x "
   },
   "dependencies": {
-    "@aurodesignsystem/auro-library": "^2.10.1",
+    "@aurodesignsystem/auro-library": "^2.8",
     "chalk": "^5.3.0",
     "lit": "^3.2.1"
   },


### PR DESCRIPTION
# Alaska Airlines Pull Request

`auro-loader` has `v2.10` of `auro-library` installed which breaks the `generateDocs` scripting, and any component that has a dependency on them. 
 
The component needs to rollback `auro-library` to `v2.8`.

**Resolves:** #46 

## Summary:

Rollback `auro-library`

## Type of change:

Please delete options that are not relevant.

- [X] Revision of an existing capability


## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
