### PR TITLE
feat: add `appearace` and deprecate `ondark` and `onlight` #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ And each of these modes support five size settings, `default`, `sm`, `md`, `lg`,
 
 For color support `<auro-loader>` supports `currentColor`, this allows for any color set on the parent element to influence the color of the loader.
 
-The `<auro-loader>` custom element also supports two pre-defined color modes: `onlight` and `ondark`.
+The `<auro-loader>` custom element also supports two pre-defined appearance modes: `appearance="brand"` and `appearance="inverse"`.
 <!-- AURO-GENERATED-CONTENT:END -->
 <!-- AURO-GENERATED-CONTENT:START (FILE:src=./docs/partials/readmeAddlInfo.md) -->
 <!-- The below content is automatically added from ./docs/partials/readmeAddlInfo.md -->

--- a/apiExamples/brandAppearance.html
+++ b/apiExamples/brandAppearance.html
@@ -1,0 +1,3 @@
+<auro-loader ringworm appearance="brand"></auro-loader>
+<auro-loader orbit appearance="brand"></auro-loader>
+<auro-loader pulse appearance="brand"></auro-loader>

--- a/apiExamples/inverseAppearance.html
+++ b/apiExamples/inverseAppearance.html
@@ -1,0 +1,3 @@
+<auro-loader ringworm appearance="inverse"></auro-loader>
+<auro-loader orbit appearance="inverse"></auro-loader>
+<auro-loader pulse appearance="inverse"></auro-loader>

--- a/apiExamples/loader_color.html
+++ b/apiExamples/loader_color.html
@@ -1,1 +1,1 @@
-<auro-loader pulse onlight md></auro-loader>
+<auro-loader pulse appearance="brand" md></auro-loader>

--- a/apiExamples/loader_color_inverse.html
+++ b/apiExamples/loader_color_inverse.html
@@ -1,0 +1,1 @@
+<auro-loader pulse appearance="inverse" md></auro-loader>

--- a/apiExamples/loader_color_ondark.html
+++ b/apiExamples/loader_color_ondark.html
@@ -1,1 +1,0 @@
-<auro-loader pulse ondark md></auro-loader>

--- a/apiExamples/ondark.html
+++ b/apiExamples/ondark.html
@@ -1,3 +1,0 @@
-<auro-loader ringworm ondark></auro-loader>
-<auro-loader orbit ondark></auro-loader>
-<auro-loader pulse ondark></auro-loader>

--- a/apiExamples/onlight.html
+++ b/apiExamples/onlight.html
@@ -1,3 +1,0 @@
-<auro-loader ringworm onLight></auro-loader>
-<auro-loader orbit onLight></auro-loader>
-<auro-loader pulse onLight></auro-loader>

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,23 +4,24 @@ The auro-loader element is an easy to use animated loader component.
 
 ## Attributes
 
-| Attribute | Type      | Description                                 |
-|-----------|-----------|---------------------------------------------|
-| `lg`      | `Boolean` | Sets size to large.                         |
-| `md`      | `Boolean` | Sets size to medium.                        |
-| `ondark`  | `Boolean` | Sets color of loader for dark backgrounds.  |
-| `onlight` | `Boolean` | sets color of loader for light backgrounds. |
-| `sm`      | `Boolean` | Sets size to small.                         |
-| `xs`      | `Boolean` | Sets size to extra small.                   |
+| Attribute | Type      | Description                              |
+|-----------|-----------|------------------------------------------|
+| `lg`      | `Boolean` | Sets size to large.                      |
+| `md`      | `Boolean` | Sets size to medium.                     |
+| `ondark`  | `Boolean` | DEPRECATED - use `appearance="inverse"`. |
+| `onlight` | `Boolean` | DEPRECATED - use `appearance="brand"`.   |
+| `sm`      | `Boolean` | Sets size to small.                      |
+| `xs`      | `Boolean` | Sets size to extra small.                |
 
 ## Properties
 
-| Property   | Attribute  | Type      | Default | Description                   |
-|------------|------------|-----------|---------|-------------------------------|
-| `laser`    | `laser`    | `boolean` | false   | Sets loader to laser type.    |
-| `orbit`    | `orbit`    | `boolean` | false   | Sets loader to orbit type.    |
-| `pulse`    | `pulse`    | `boolean` | false   | Sets loader to pulse type.    |
-| `ringworm` | `ringworm` | `boolean` | false   | Sets loader to ringworm type. |
+| Property     | Attribute    | Type      | Default     | Description                                      |
+|--------------|--------------|-----------|-------------|--------------------------------------------------|
+| `appearance` | `appearance` | `string`  | "'default'" | Defines whether the button is intended for lighter or darker backgrounds, or if it should use the brand color regardless of the background. |
+| `laser`      | `laser`      | `boolean` | false       | Sets loader to laser type.                       |
+| `orbit`      | `orbit`      | `boolean` | false       | Sets loader to orbit type.                       |
+| `pulse`      | `pulse`      | `boolean` | false       | Sets loader to pulse type.                       |
+| `ringworm`   | `ringworm`   | `boolean` | false       | Sets loader to ringworm type.                    |
 
 ## CSS Shadow Parts
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -85,34 +85,36 @@ Use the `lg` boolean attribute for a pre-defined size. Type `laser` does not sup
 
 </auro-accordion>
 
-#### `onlight`
+### Appearance examples <a name="appearance"></a>
 
-Use the `onlight` boolean attribute for a pre-defined color. Type `laser` is supported, but not shown due to fixed positioning.
+#### `appearance="brand"`
+
+Use the `appearance="brand"` attribute for a brand color. Type `laser` is supported, but not shown due to fixed positioning.
 
 <div class="exampleWrapper">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/onlight.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/brandAppearance.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/onlight.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/brandAppearance.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>
 
-#### `ondark`
+#### `appearance="inverse"`
 
-Use the `ondark` boolean attribute for a pre-defined color. Type `laser` is supported, but not shown due to fixed positioning.
+Use the `appearance="inverse"` attribute for a pre-defined color. Type `laser` is supported, but not shown due to fixed positioning.
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/ondark.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/inverseAppearance.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/ondark.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/inverseAppearance.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/docs/partials/description.md
+++ b/docs/partials/description.md
@@ -6,4 +6,4 @@ And each of these modes support five size settings, `default`, `sm`, `md`, `lg`,
 
 For color support `<auro-loader>` supports `currentColor`, this allows for any color set on the parent element to influence the color of the loader.
 
-The `<auro-loader>` custom element also supports two pre-defined color modes: `onlight` and `ondark`.
+The `<auro-loader>` custom element also supports two pre-defined appearance modes: `appearance="brand"` and `appearance="inverse"`.

--- a/docs/partials/index.md
+++ b/docs/partials/index.md
@@ -50,7 +50,7 @@ The `<auro-loader>` element supports a scale of sizes. Options are `[sm, md, lg,
 
 ## Color support
 
-The `<auro-loader>` element supports a scale of pre-defines color options. Options are `[onlight, ondark]`.
+The `<auro-loader>` element supports a scale of pre-defines color options. Options are `appearance="brand", appearance="inverse"`.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/loader_color.html) -->
@@ -66,14 +66,14 @@ The `<auro-loader>` element supports a scale of pre-defines color options. Optio
 </auro-accordion>
 
 <div class="exampleWrapper--ondark">
-  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/loader_color_ondark.html) -->
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/loader_color_inverse.html) -->
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 
 <auro-accordion alignRight>
   <span slot="trigger">See code</span>
 
-<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/loader_color_ondark.html) -->
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=../apiExamples/loader_color_inverse.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/scripts/wca/auro-loader.js
+++ b/scripts/wca/auro-loader.js
@@ -3,13 +3,6 @@ import { AuroLoader } from "../../src/auro-loader.js";
 /**
  * The auro-loader element is an easy to use animated loader component.
  *
- * @attr {Boolean} ondark - Sets color of loader for dark backgrounds.
- * @attr {Boolean} onlight - sets color of loader for light backgrounds.
- * @attr {Boolean} xs - Sets size to extra small.
- * @attr {Boolean} sm - Sets size to small.
- * @attr {Boolean} md - Sets size to medium.
- * @attr {Boolean} lg - Sets size to large.
- * @csspart element - Apply style to adjust speed of animation.
  */
 class AuroLoaderWCA extends AuroLoader {}
 

--- a/src/auro-loader.js
+++ b/src/auro-loader.js
@@ -10,10 +10,21 @@ import colorCss from "./styles/color.scss";
 import styleCss from "./styles/style.scss";
 import tokensCss from "./styles/tokens.scss";
 
+/**
+ * @attr {Boolean} ondark - DEPRECATED - use `appearance="inverse"`.
+ * @attr {Boolean} onlight - DEPRECATED - use `appearance="brand"`.
+ * @attr {Boolean} xs - Sets size to extra small.
+ * @attr {Boolean} sm - Sets size to small.
+ * @attr {Boolean} md - Sets size to medium.
+ * @attr {Boolean} lg - Sets size to large.
+ * @csspart element - Apply style to adjust speed of animation.
+ */
 export class AuroLoader extends LitElement {
   constructor() {
     super();
 
+
+    this.appearance = "default";
     /**
      * @private
      */
@@ -43,6 +54,17 @@ export class AuroLoader extends LitElement {
   // function to define props used within the scope of this component
   static get properties() {
     return {
+
+      /**
+       * Defines whether the button is intended for lighter or darker backgrounds, or if it should use the brand color regardless of the background.
+       * @property {'default', 'inverse', 'brand'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true
+      },
+
       /**
        * Sets loader to laser type.
        */

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -15,11 +15,13 @@
   border-color: var(--ds-auro-loader-border-color);
 }
 
-:host([onlight]) {
+:host([onlight]),
+:host([appearance="brand"]) {
   --ds-auro-loader-color: var(--ds-basic-color-brand-primary, #{v.$ds-basic-color-brand-primary});
 }
 
-:host([ondark]) {
+:host([ondark]),
+:host([appearance="inverse"]) {
   --ds-auro-loader-color: var(--ds-basic-color-texticon-inverse, #{v.$ds-basic-color-texticon-inverse});
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #71 

This is to replace `onDark` attr with `appearance` attr. 
- Adding `appearance` with its default value `default`
- Mark `onDark` and `onLight` as deprecated in the api table
- Replace `onDark` with `appearance="inverse"` in all examples 
- Replace `onLight` with `appearance="brand"` in all examples 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Introduce a new "appearance" attribute to control the loader's color modes, deprecate the old "ondark" and "onlight" boolean attributes, and update the component code, styles, documentation, and examples to use the new API.

New Features:
- Add appearance attribute with default value "default" to select between default, inverse, and brand color modes

Enhancements:
- Mark `ondark` and `onlight` attributes as deprecated in the API and replace them with `appearance="inverse"` and `appearance="brand"` respectively
- Update component definition, CSS selectors, and WCA script to support the new appearance property and remove legacy attribute references
- Remove obsolete example files and add new examples showcasing the brand and inverse appearance modes

Documentation:
- Revise API documentation, README, and partials to describe the appearance attribute and deprecation of old attributes
- Update all code examples to use `appearance` instead of `ondark`/`onlight`