### PR TITLE
fix: set correct size on pulse and orbit loader #60, #63

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ The auro-loader element is an easy to use animated loader component.
 
 | Property     | Attribute    | Type      | Default     | Description                                      |
 |--------------|--------------|-----------|-------------|--------------------------------------------------|
-| `appearance` | `appearance` | `string`  | "'default'" | Defines whether the button is intended for lighter or darker backgrounds, or if it should use the brand color regardless of the background. |
+| `appearance` | `appearance` | `string`  | "'default'" | Defines whether the loader is intended for lighter or darker backgrounds, or if it should use the brand color regardless of the background. |
 | `laser`      | `laser`      | `boolean` | false       | Sets loader to laser type.                       |
 | `orbit`      | `orbit`      | `boolean` | false       | Sets loader to orbit type.                       |
 | `pulse`      | `pulse`      | `boolean` | false       | Sets loader to pulse type.                       |

--- a/src/auro-loader.js
+++ b/src/auro-loader.js
@@ -56,7 +56,7 @@ export class AuroLoader extends LitElement {
     return {
 
       /**
-       * Defines whether the button is intended for lighter or darker backgrounds, or if it should use the brand color regardless of the background.
+       * Defines whether the loader is intended for lighter or darker backgrounds, or if it should use the brand color regardless of the background.
        * @property {'default', 'inverse', 'brand'}
        * @default 'default'
        */

--- a/src/styles/partials/_base.scss
+++ b/src/styles/partials/_base.scss
@@ -21,6 +21,7 @@
   border-radius: 100%;
   border-style: solid;
   border-width: 0;
+  box-sizing: border-box;
 }
 
 :host([xs]),

--- a/src/styles/partials/_pulse.scss
+++ b/src/styles/partials/_pulse.scss
@@ -13,7 +13,7 @@
 
 :host([pulse]) {
   width: calc((3 * 1rem) + (var(--margin) * 6));
-  height: 1.5rem;
+  height: calc((1rem) + (var(--margin) * 2));
 }
 
 :host([pulse]) > span {
@@ -24,8 +24,8 @@
 }
 
 :host([pulse][xs]) {
-  width: calc((3 * .85rem) + (var(--margin-xs) * 6));
-  height: 1.55rem;
+  width: calc((3 * .65rem) + (var(--margin-xs) * 6));
+  height: calc((.65rem) + (var(--margin-xs) * 2));
 }
 
 :host([pulse][xs]) > span {
@@ -36,7 +36,7 @@
 
 :host([pulse][sm]) {
   width: calc((3 * 2rem) + (var(--margin-sm) * 6));
-  height: 2.5rem;
+  height: calc((2rem) + (var(--margin-sm) * 2));
 }
 
 :host([pulse][sm]) > span {
@@ -47,7 +47,7 @@
 
 :host([pulse][md]) {
   width: calc((3 * 3rem) + (var(--margin-md) * 6));
-  height: 3.5rem;
+  height: calc((3rem) + (var(--margin-md) * 2));
 }
 
 :host([pulse][md]) > span {
@@ -58,7 +58,7 @@
 
 :host([pulse][lg]) {
   width: calc((3 * 5rem) + (var(--margin-lg) * 6));
-  height: 5.5rem;
+  height: calc((5rem) + (var(--margin-lg) * 2));
 }
 
 :host([pulse][lg]) > span {


### PR DESCRIPTION
# Alaska Airlines Pull Request

- fix pulse loader to have the correct height that also calculating margins. 
- fix orbit loader's graphics to fit to the container

Closes #60 #63 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix loader sizing by including margin in height calculations for pulse variants and ensure loader graphics fit container by adding box-sizing rule.

Enhancements:
- Calculate pulse loader height using margin variables for accurate sizing across default and size-specific variants
- Add box-sizing: border-box to loader containers to ensure orbit graphics fit correctly